### PR TITLE
Prevent KeyError when page_template not supplied

### DIFF
--- a/endless_pagination/views.py
+++ b/endless_pagination/views.py
@@ -74,7 +74,7 @@ class MultipleObjectMixin(object):
         the template will be ``blog/entry_list_page.html``.
         """
         queryset = kwargs.pop('object_list')
-        page_template = kwargs.pop('page_template')
+        page_template = kwargs.pop('page_template', None)
 
         context_object_name = self.get_context_object_name(queryset)
         context = {'object_list': queryset, 'view': self}


### PR DESCRIPTION
When `page_template` is not supplied as a kwarg via `.as_View()` a KeyError is raised because `.pop()` is used on a dictionary with no default value specified.
