### PR TITLE
Fix for twitter style onscroll pagination

### DIFF
--- a/endless_pagination/static/endless_pagination/js/endless-pagination.js
+++ b/endless_pagination/static/endless_pagination/js/endless-pagination.js
@@ -69,7 +69,7 @@
 
             // On scroll pagination.
             if (settings.paginateOnScroll) {
-                var win = $(window),
+                var win = $(window);
                 var doc = $(document);
                 doc.scroll(function(){
                     if (doc.height() - win.height() -


### PR DESCRIPTION
I had this issue. The page loads with a show_more link at the end. When show_more link is clicked, it's loading the next page of items via ajax but this doesn't happen automatically as it should be when we set paginateOnScroll:true. [StackOverflow Question](http://stackoverflow.com/questions/18082640/how-to-enable-load-on-scroll-in-django-endless-pagination) here
