### PR TITLE
zip_safe=False flag needs to be set

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,4 +76,5 @@ with VenvLinkDeleted():
             'Programming Language :: Python :: 3',
             'Topic :: Utilities',
         ],
+        zip_safe=False,
     )


### PR DESCRIPTION
When installing via setuptools (and not via pip directly), the resulting egg's assets aren't available to e.g. `collectstatic` for some reason.  Setting the setuptools `zip_safe` flag fixes this.
