### PR TITLE
add page info when render page list

### DIFF
--- a/endless_pagination/models.py
+++ b/endless_pagination/models.py
@@ -169,7 +169,10 @@ class PageList(utils.UnicodeMixin):
                     pages.append(self.last_as_arrow())
                 else:
                     pages.append(self[item])
-            context = RequestContext(self._request, {'pages': pages})
+            context = RequestContext(
+                    self._request,
+                    {'pages': pages, 'page_info': self}
+                    )
             return loader.render_to_string('endless/show_pages.html', context)
         return ''
 


### PR DESCRIPTION
{% show_pages %} tag only get page list, I add page info
in context so I can get the page info.
