### PR TITLE
Loading within table

### DIFF
--- a/endless_pagination/templates/endless/show_more_table.html
+++ b/endless_pagination/templates/endless/show_more_table.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+{% if querystring %}
+<tr class="endless_container">
+  <td colspan="100%">
+    <a class="endless_more" href="{{ path }}{{ querystring }}" rel="{{ querystring_key }}">
+      {% if label %}{{ label }}{% else %}{% trans "more" %}{% endif %}
+    </a>
+    <span class="endless_loading" style="display: none;">{{ loading|safe }}</span>
+  </td> 
+</tr>
+{% endif %}

--- a/endless_pagination/templatetags/endless.py
+++ b/endless_pagination/templatetags/endless.py
@@ -366,6 +366,31 @@ def show_more(context, label=None, loading=settings.LOADING):
     return {}
 
 
+@register.inclusion_tag('endless/show_more_table.html', takes_context=True)
+def show_more_table(context, label=None, loading=settings.LOADING):
+
+    """Show the link to get the next page in a Twitter-like pagination in a
+    template for table.
+
+    Usage::
+
+        {% show_more_table %}
+
+    Alternatively you can override the label passed to the default template::
+
+        {% show_more_table "even more" %}
+
+    You can override the loading text too::
+
+        {% show_more_table "even more" "working" %}
+
+    Must be called after ``{% paginate objects %}``.
+    """
+    # This template tag could raise a PaginationError: you have to call
+    # *paginate* or *lazy_paginate* before including the showmore template.
+    return show_more(context, label, loading)
+
+
 @register.tag
 def get_pages(parser, token):
     """Add to context the list of page links.

--- a/tests/project/templates/twitter/table.html
+++ b/tests/project/templates/twitter/table.html
@@ -1,0 +1,20 @@
+{% load endless %}
+
+{% paginate 5 objects %}
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Content</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for object in objects %}
+    <tr>
+      <td>{{ object.title }}</td>
+      <td>{{ object.contents }}</td>
+    </tr>
+  {% endfor %}
+  {% show_more_table "More results" %}
+  </tbody>
+</table>


### PR DESCRIPTION
Thanks to the issue #54, I have implemented a templatetag **show_more_table** which works like **show_more** within HTML table.
##### Small demo:

``` html
{% load endless %}

{% paginate 5 objects %}
<table>
  <thead>
    <tr>
      <th>Title</th>
      <th>Content</th>
    </tr>
  </thead>
  <tbody>
  {% for object in objects %}
    <tr>
      <td>{{ object.title }}</td>
      <td>{{ object.contents }}</td>
    </tr>
  {% endfor %}
  {% show_more_table "More results" %}
  </tbody>
</table>
```
