### PR TITLE
Update loaders.py

### DIFF
--- a/endless_pagination/loaders.py
+++ b/endless_pagination/loaders.py
@@ -3,7 +3,8 @@
 from __future__ import unicode_literals
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
+#from django.utils.importlib import import_module
+from importlib import import_module
 
 
 def load_object(path):


### PR DESCRIPTION
django.utils.importlib is a compatibility library for when Python 2.6 was still supported. It has been obsolete since Django 1.7, which dropped support for Python 2.6, and is removed in 1.9 per the deprecation cycle.

Use Python's import_module function instead:

`from importlib import import_modul`

For help :: [SO](https://stackoverflow.com/a/32763639/3128823)